### PR TITLE
guard let to images

### DIFF
--- a/challangeNetflix/ViewController.swift
+++ b/challangeNetflix/ViewController.swift
@@ -61,9 +61,12 @@ class ViewController: UIViewController, UICollectionViewDelegate, UICollectionVi
        
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MovieCell", for: indexPath) as! MovieCell
         
-        let urlImage: URL? = movies[indexPath.row].images[2]
+        guard let urlImage: URL = movies[indexPath.row].images[2] else {
+            print(Error.self)
+            return UICollectionViewCell()
+        }
         
-        cell.configureImage(url: urlImage!)
+        cell.configureImage(url: urlImage)
         
         return cell
     }


### PR DESCRIPTION
## Descrição 

* PR com alternativa de resolução da issue: https://github.com/involvestecnologia/mnc-ios-movies/issues/101

* Guard let implementado para evitar a quebra do app em caso de algum problema no carregamento das imagens do json.
